### PR TITLE
#30 Add sessionize to global window type

### DIFF
--- a/app/(site)/schedule/page.tsx
+++ b/app/(site)/schedule/page.tsx
@@ -6,11 +6,11 @@ import { ConferenceScheduleUrl } from '@/types/SanityFetches';
 import styles from './schedule.module.scss';
 
 // generateMetaData isn't working for some reason, likely something to do with 'use client' or sessionize
-export async function generateMetadata() {
-	return {
-		title: `UtahJS | Schedule`,
-	};
-}
+// export async function generateMetadata() {
+// 	return {
+// 		title: `UtahJS | Schedule`,
+// 	};
+// }
 
 export default function Schedule() {
 	const [schedule, setSchedule] = useState<ConferenceScheduleUrl | null>(null);

--- a/types/global.ts
+++ b/types/global.ts
@@ -1,0 +1,7 @@
+declare global {
+	interface Window {
+		sessionize: any;
+	}
+}
+
+export {};


### PR DESCRIPTION
## Overview

Adds a `global.ts` file to the `types` directory that extends the global Window type to prevent TS errors from trying to access `window.sessionize` for the schedule

closes #30 

## Test Plan

can be tested ensuring there is no longer a typescript error in the `schedule/page.tsx` file, and/or by trying to run `npm run build` on this branch and ensuring it completes successfully