### PR TITLE
Make husky lint run as pre-commit [32]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,26 @@
+{
+	"env": {
+		"node": true,
+		"commonjs": true,
+		"es6": true
+	},
+	"parser": "@typescript-eslint/parser",
+	"plugins": [
+		"@typescript-eslint"
+	],
+	"extends": [
+		"next/core-web-vitals",
+		"@sanity/eslint-config-studio",
+		"eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"plugin:prettier/recommended"
+	],
+	"rules": {
+		"@typescript-eslint/no-unused-vars": [
+			"error",
+			{
+				"argsIgnorePattern": "^_"
+			}
+		]
+	}
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-	"extends": ["next/core-web-vitals", "@sanity/eslint-config-studio"],
-	"rules": {
-		"quotes": ["error", "backtick"]
-	}
-}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo 'husky pre commit hook'
+npm run pre-commit

--- a/app/(site)/schedule/page.tsx
+++ b/app/(site)/schedule/page.tsx
@@ -6,11 +6,11 @@ import { ConferenceScheduleUrl } from '@/types/SanityFetches';
 import styles from './schedule.module.scss';
 
 // generateMetaData isn't working for some reason, likely something to do with 'use client' or sessionize
-export async function generateMetadata() {
-	return {
-		title: `UtahJS | Schedule`,
-	};
-}
+// export async function generateMetadata() {
+// 	return {
+// 		title: `UtahJS | Schedule`,
+// 	};
+// }
 
 export default function Schedule() {
 	const [schedule, setSchedule] = useState<ConferenceScheduleUrl | null>(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,14 @@
 				"@types/node": "18.15.0",
 				"@types/react": "18.2.8",
 				"@types/react-dom": "18.0.11",
+				"@typescript-eslint/eslint-plugin": "^5.62.0",
+				"@typescript-eslint/parser": "^5.0.0",
 				"eslint": "8.41.0",
+				"eslint-config-prettier": "^8.8.0",
+				"eslint-plugin-prettier": "^5.0.0",
 				"husky": "^8.0.3",
 				"lint-staged": "^13.2.2",
-				"prettier": "^2.8.8",
+				"prettier": "^3.0.0",
 				"sass": "^1.62.1",
 				"typescript": "5.1.3"
 			}
@@ -2493,7 +2497,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-			"dev": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -2508,7 +2511,6 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
 			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
-			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -2517,7 +2519,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
 			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
-			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -2540,7 +2541,6 @@
 			"version": "8.41.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
 			"integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
-			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -2574,7 +2574,6 @@
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
 			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -2588,7 +2587,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"dev": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -2600,8 +2598,7 @@
 		"node_modules/@humanwhocodes/object-schema": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
 		},
 		"node_modules/@iarna/toml": {
 			"version": "2.2.3",
@@ -3778,17 +3775,17 @@
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
-			"integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/type-utils": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/type-utils": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"natural-compare-lite": "^1.4.0",
 				"semver": "^7.3.7",
@@ -3812,13 +3809,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
-			"integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/typescript-estree": "5.60.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3838,12 +3835,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
-			"integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/visitor-keys": "5.60.0"
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3854,13 +3851,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
-			"integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -3881,9 +3878,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
-			"integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -3893,12 +3890,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
-			"integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/visitor-keys": "5.60.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -3919,17 +3916,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
-			"integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
 				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/typescript-estree": "5.60.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"eslint-scope": "^5.1.1",
 				"semver": "^7.3.7"
 			},
@@ -3967,11 +3964,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
-			"integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dependencies": {
-				"@typescript-eslint/types": "5.60.0",
+				"@typescript-eslint/types": "5.62.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -4195,7 +4192,6 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -4236,7 +4232,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"devOptional": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -5530,7 +5525,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -5787,7 +5781,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -5867,7 +5860,6 @@
 			"version": "8.41.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
 			"integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
-			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.4.0",
@@ -5942,6 +5934,18 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+			"integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+			"dev": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
@@ -6132,6 +6136,35 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/eslint-plugin-prettier": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+			"integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+			"dev": true,
+			"dependencies": {
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.8.5"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/prettier"
+			},
+			"peerDependencies": {
+				"@types/eslint": ">=8.0.0",
+				"eslint": ">=8.0.0",
+				"prettier": ">=3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/eslint": {
+					"optional": true
+				},
+				"eslint-config-prettier": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/eslint-plugin-react": {
 			"version": "7.32.2",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
@@ -6210,7 +6243,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
 			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
-			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -6237,7 +6269,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6246,7 +6277,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -6261,7 +6291,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -6277,7 +6306,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6286,7 +6314,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -6298,7 +6325,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -6310,7 +6336,6 @@
 			"version": "9.5.2",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
 			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
-			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -6339,7 +6364,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -6351,7 +6375,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -6425,6 +6448,12 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
+		"node_modules/fast-diff": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+			"dev": true
+		},
 		"node_modules/fast-glob": {
 			"version": "3.2.12",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -6454,8 +6483,7 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"devOptional": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
@@ -6474,7 +6502,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-			"dev": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -6525,7 +6552,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-			"dev": true,
 			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
@@ -6537,8 +6563,7 @@
 		"node_modules/flatted": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
 		},
 		"node_modules/flush-write-stream": {
 			"version": "2.0.0",
@@ -6897,7 +6922,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -6918,7 +6942,6 @@
 			"version": "13.20.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
 			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -6933,7 +6956,6 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -6995,17 +7017,10 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
-		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
 		"node_modules/groq": {
 			"version": "3.14.1",
@@ -7284,7 +7299,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
 			"integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -7630,7 +7645,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7884,14 +7898,12 @@
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"devOptional": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -7952,7 +7964,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-			"dev": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -8180,8 +8191,7 @@
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
 		},
 		"node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -8598,8 +8608,7 @@
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
 		},
 		"node_modules/natural-compare-lite": {
 			"version": "1.4.0",
@@ -8898,7 +8907,6 @@
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-			"dev": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -9236,24 +9244,35 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+			"integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"dependencies": {
+				"fast-diff": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/pretty-ms": {
@@ -10361,7 +10380,7 @@
 			"version": "1.63.6",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
 			"integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -10808,7 +10827,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -10977,8 +10995,7 @@
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
 		"node_modules/throttle-debounce": {
 			"version": "5.0.0",
@@ -11134,7 +11151,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-			"dev": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -11184,7 +11200,6 @@
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
 			"integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
-			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11337,7 +11352,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"devOptional": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
 		"start": "next dev",
 		"build": "next build",
 		"production": "next start",
+		"pre-commit": "lint-staged",
+		"prepare": "husky install",
 		"lint": "next lint"
 	},
 	"dependencies": {
@@ -33,22 +35,24 @@
 		"@types/node": "18.15.0",
 		"@types/react": "18.2.8",
 		"@types/react-dom": "18.0.11",
+		"@typescript-eslint/eslint-plugin": "^5.62.0",
+		"@typescript-eslint/parser": "^5.0.0",
 		"eslint": "8.41.0",
+		"eslint-config-prettier": "^8.8.0",
+		"eslint-plugin-prettier": "^5.0.0",
 		"husky": "^8.0.3",
 		"lint-staged": "^13.2.2",
-		"prettier": "^2.8.8",
+		"prettier": "^3.0.0",
 		"sass": "^1.62.1",
 		"typescript": "5.1.3"
 	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
 	"lint-staged": {
-		"*.{js,jsx,ts,tsx,json,css,scss,md}": [
-			"eslint --fix",
-			"prettier --write"
+		"*.{js,jsx,ts,tsx,css,scss,md}": [
+			"prettier --write",
+			"eslint --max-warnings 0"
+		],
+		"*.json": [
+			"prettier --list-different"
 		]
 	}
 }

--- a/types/global.ts
+++ b/types/global.ts
@@ -1,0 +1,7 @@
+declare global {
+	interface Window {
+		sessionize: any;
+	}
+}
+
+export {};


### PR DESCRIPTION
closes #32 

This mainly corrects the husky setup to ensure it runs on pre-commit. I updated some things surrounding that though. Feel free to ask questions about any updates I made that are unclear or concerning, but I ran into some conflicting things that were causing issues once I got husky setup. I also extended the eslint config so we could get eslint errors for prettier issues in the file.