### PR TITLE
Metadata -- document title fixes [#31]

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,8 +1,9 @@
-import { Metadata } from 'next';
 import styles from './layout/layout.module.scss';
 import Header from './layout/header';
 import Footer from './layout/footer';
 import '../styles/main.scss';
+
+import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: `UtahJS - JavaScript Engineers of Utah`,

--- a/app/(site)/schedule/page.tsx
+++ b/app/(site)/schedule/page.tsx
@@ -5,19 +5,13 @@ import { getConferenceScheduleData } from '@/sanity/sanityFetch-utils';
 import { ConferenceScheduleUrl } from '@/types/SanityFetches';
 import styles from './schedule.module.scss';
 
-// generateMetaData isn't working for some reason, likely something to do with 'use client' or sessionize
-// export async function generateMetadata() {
-// 	return {
-// 		title: `UtahJS | Schedule`,
-// 	};
-// }
-
 export default function Schedule() {
 	const [schedule, setSchedule] = useState<ConferenceScheduleUrl | null>(null);
 
 	useEffect(() => {
 		getConferenceScheduleData().then((data) => {
 			setSchedule(data);
+			document.title = `UtahJS | Schedule`;
 		});
 
 		// load sessionize embed

--- a/app/(site)/speakers/page.tsx
+++ b/app/(site)/speakers/page.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { Metadata } from 'next';
 import { getPastSpeakersData } from '@/sanity/sanityFetch-utils';
 import { Speaker } from '@/types/speaker';
 import { getData } from '@/utils/fetch';
 import styles from './speakers.module.scss';
 
-export const metadata: Metadata = {
-	title: `UtahJS | 2023 Speakers`,
-	description: `Get involved in JavaScript in Utah! Let's learn together`,
-};
+import type { Metadata } from 'next';
+
+export async function generateMetadata(): Promise<Metadata> {
+	const sessionizeUrls = await getPastSpeakersData();
+	const currentYear = new Date(sessionizeUrls[0].date).getFullYear();
+	return {
+		title: `UtahJS | ${currentYear} Speakers`,
+	};
+}
 
 export default async function Speakers() {
 	const sessionizeUrls = await getPastSpeakersData();


### PR DESCRIPTION
This fixes the broken document title on the `use client` schedule page and makes the speaker page title dynamic with relation to the current year.

Pretty sure this doesn't do everything that the ticket was hoping for, but I think its a good start and can help move forward follow up work

To test: Ensure the schedule page shows a schedule-page-specific title instead of the default "UtahJS - JavaScript Engineers of Utah" title and ensure the speakers page correctly shows the year for each speaker page, but most importantly the current year page.

note: I also updated some import ordering. I think maybe we should define a standard import order and make a pass to ensure everything lines up. I particularly prefer using `import type` when importing a type, for clarity, and find that those are best placed after standard imports

closes #31 