### PR TITLE
Changed no-explicit-any to a warning in .eslintrc and changed noImpli…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,6 @@
 				"argsIgnorePattern": "^_"
 			}
 		],
-		"@typescript-eslint/no-explicit-any": "off"
+		"@typescript-eslint/no-explicit-any": 1
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"esModuleInterop": true,
 		"module": "esnext",
 		"moduleResolution": "node",
-		"noImplicitAny": false,
+		"noImplicitAny": true,
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "preserve",


### PR DESCRIPTION
…citAny to true in tsconfig.json

I ran `npm run lint` and got no errors or warnings, the pre commit hook also didn't find any issues. 

I will say that in the sanity folder, their are schemas that have "any" being used, stuff like this:

`export const myStructure = (S: any) =>`

I don't know what type Sanity uses and I'm not sure how to find this info, I'm open to ideas on how to handle this.

