### PR TITLE
48 populate meta data from sanity

### DIFF
--- a/app/(site)/conference/page.tsx
+++ b/app/(site)/conference/page.tsx
@@ -3,8 +3,24 @@ import { getConferenceData } from '@/sanity/sanityFetch-utils';
 import styles from './conference.module.scss';
 
 export async function generateMetadata() {
+	const conferenceData = await getConferenceData();
 	return {
-		title: `UtahJS | Conference`,
+		title: conferenceData.heroSection.heroHeader,
+		description: conferenceData.heroSection.subtitle,
+		openGraph: {
+			title: conferenceData.heroSection.heroHeader,
+			description: conferenceData.heroSection.subtitle,
+			url: `https://utahjs.com/`,
+			type: 'website',
+			siteName: 'UtahJS',
+			images: conferenceData.heroSection?.heroImage || '/logo.png',
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title: conferenceData.heroSection.heroHeader,
+			creator: '@utjs',
+			images: conferenceData.heroSection?.heroImage || '/logo.png',
+		},
 	};
 }
 

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -6,8 +6,35 @@ import '../styles/main.scss';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
+	authors: [{ name: 'freeCodeCamp - SLC Study Group' }],
 	title: `UtahJS - JavaScript Engineers of Utah`,
 	description: `Get involved in JavaScript in Utah! Let's learn together`,
+	openGraph: {
+		title: `UtahJS - JavaScript Engineers of Utah`,
+		description: `Get involved in JavaScript in Utah! Let's learn together`,
+		url: `https://utahjs.com/`,
+		type: 'website',
+		siteName: 'UtahJS',
+		images: [
+			{
+				url: '/logo.png',
+				width: 64,
+				height: 81,
+			},
+		],
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: `UtahJS - JavaScript Engineers of Utah`,
+		creator: '@utjs',
+		images: [
+			{
+				url: '/logo.png',
+				width: 64,
+				height: 81,
+			},
+		],
+	},
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/sanity/sanityFetch-utils.ts
+++ b/sanity/sanityFetch-utils.ts
@@ -59,10 +59,21 @@ export async function getFooterData(): Promise<Footer> {
 }
 
 export async function getHomeData(): Promise<Home> {
-	return createClient(clientConfig).fetch(groq`*[_type == "home"][0]{
+	return createClient(clientConfig).fetch(groq`*[_type == "homePage"][0]{
 		_id,
 		_createdAt,
 		_updatedAt,
+		"metaData": metaData->{
+          ...,
+          openGraph {
+            ...,
+            "ogImageUrl": ogImage.asset->url,
+          },
+          twitter {
+            ...,
+            "twitterImageUrl": twitterImage.asset->url,
+          },
+        },
 		"pageTitle": page_title,
 		"heroSection": {
 			"heroBackgroundImageUrl": hero_section.hero_background_image.asset->url,

--- a/sanity/sanityFetch-utils.ts
+++ b/sanity/sanityFetch-utils.ts
@@ -63,7 +63,7 @@ export async function getHomeData(): Promise<Home> {
 		_id,
 		_createdAt,
 		_updatedAt,
-		"metaData": metaData->{
+		metaData->{
           ...,
           openGraph {
             ...,

--- a/sanity/schemas/pages/conferencePage-schema.ts
+++ b/sanity/schemas/pages/conferencePage-schema.ts
@@ -4,6 +4,12 @@ const conferencePage = {
 	type: `document`,
 	fields: [
 		{
+			name: `metaData`,
+			title: `Metadata`,
+			type: `reference`,
+			to: [{ type: `metaData` }],
+		},
+		{
 			name: `pageTitle`,
 			title: `Page Title`,
 			type: `string`,
@@ -67,7 +73,7 @@ const conferencePage = {
 							name: `url`,
 							title: `URL`,
 							type: `url`,
-							validation: (rule: { uri: (arg0: { allowRelative: boolean; scheme: string[] }) => any }) =>
+							validation: (rule: { uri: (arg0: { allowRelative: boolean; scheme: string[] }) => unknown }) =>
 								rule.uri({
 									allowRelative: true,
 									scheme: [`http`, `https`, `mailto`, `tel`],
@@ -94,7 +100,7 @@ const conferencePage = {
 							name: `url`,
 							title: `URL`,
 							type: `url`,
-							validation: (rule: { uri: (arg0: { allowRelative: boolean; scheme: string[] }) => any }) =>
+							validation: (rule: { uri: (arg0: { allowRelative: boolean; scheme: string[] }) => unknown }) =>
 								rule.uri({
 									allowRelative: true,
 									scheme: [`http`, `https`, `mailto`, `tel`],

--- a/sanity/schemas/pages/homePage-schema.ts
+++ b/sanity/schemas/pages/homePage-schema.ts
@@ -13,6 +13,12 @@ const homePage = {
 	type: `document`,
 	fields: [
 		{
+			name: `metaData`,
+			title: `Metadata`,
+			type: `reference`,
+			to: [{ type: `metaData` }],
+		},
+		{
 			name: `pageTitle`,
 			title: `Page Title`,
 			type: `string`,

--- a/sanity/schemas/siteSettings/metaData-schema.ts
+++ b/sanity/schemas/siteSettings/metaData-schema.ts
@@ -70,50 +70,50 @@ const metaData = {
 					title: `Open Graph Image Height`,
 					type: `number`,
 				},
+			],
+		},
+		{
+			name: `twitter`,
+			title: `Twitter`,
+			type: `object`,
+			fields: [
 				{
-					name: `twitter`,
-					title: `Twitter`,
-					type: `object`,
-					fields: [
-						{
-							name: `card`,
-							title: `Twitter Card Size`,
-							type: `string`,
-							options: {
-								list: [
-									{ title: `Summary`, value: `summary` },
-									{ title: `Summary Large Image`, value: `summary_large_image` },
-									{ title: `App`, value: `app` },
-									{ title: `Player`, value: `player` },
-								],
-							},
-						},
-						{
-							name: `title`,
-							title: `Title`,
-							type: `string`,
-						},
-						{
-							name: `creator`,
-							title: `Creator`,
-							type: `string`,
-						},
-						{
-							name: `twitterImage`,
-							title: `Twitter Image`,
-							type: `image`,
-						},
-						{
-							name: `twitterImageWidth`,
-							title: `Open Graph Image Width`,
-							type: `number`,
-						},
-						{
-							name: `twitterImageHeight`,
-							title: `Open Graph Image Height`,
-							type: `number`,
-						},
-					],
+					name: `card`,
+					title: `Twitter Card Size`,
+					type: `string`,
+					options: {
+						list: [
+							{ title: `Summary`, value: `summary` },
+							{ title: `Summary Large Image`, value: `summary_large_image` },
+							{ title: `App`, value: `app` },
+							{ title: `Player`, value: `player` },
+						],
+					},
+				},
+				{
+					name: `title`,
+					title: `Title`,
+					type: `string`,
+				},
+				{
+					name: `creator`,
+					title: `Creator`,
+					type: `string`,
+				},
+				{
+					name: `twitterImage`,
+					title: `Twitter Image`,
+					type: `image`,
+				},
+				{
+					name: `twitterImageWidth`,
+					title: `Open Graph Image Width`,
+					type: `number`,
+				},
+				{
+					name: `twitterImageHeight`,
+					title: `Open Graph Image Height`,
+					type: `number`,
 				},
 			],
 		},

--- a/sanity/schemas/siteSettings/metaData-schema.ts
+++ b/sanity/schemas/siteSettings/metaData-schema.ts
@@ -13,6 +13,110 @@ const metaData = {
 			title: `Site Description`,
 			type: `text`,
 		},
+		{
+			name: `authors`,
+			title: `Site Authors`,
+			type: `array`,
+			of: [
+				{
+					type: `object`,
+					name: `author`,
+					fields: [{ type: `string`, name: `name`, title: `Name` }],
+				},
+			],
+		},
+		{
+			name: `openGraph`,
+			title: `Open Graph`,
+			type: `object`,
+			fields: [
+				{
+					name: `title`,
+					title: `Title`,
+					type: `string`,
+				},
+				{
+					name: `description`,
+					title: `Description`,
+					type: `text`,
+				},
+				{
+					name: `url`,
+					title: `URL`,
+					type: `url`,
+				},
+				{
+					name: `type`,
+					title: `Type`,
+					type: `string`,
+				},
+				{
+					name: `siteName`,
+					title: `Site Name`,
+					type: `string`,
+				},
+				{
+					name: `ogImage`,
+					title: `Open Graph Image`,
+					type: `image`,
+				},
+				{
+					name: `ogImageWidth`,
+					title: `Open Graph Image Width`,
+					type: `number`,
+				},
+				{
+					name: `ogImageHeight`,
+					title: `Open Graph Image Height`,
+					type: `number`,
+				},
+				{
+					name: `twitter`,
+					title: `Twitter`,
+					type: `object`,
+					fields: [
+						{
+							name: `card`,
+							title: `Twitter Card Size`,
+							type: `string`,
+							options: {
+								list: [
+									{ title: `Summary`, value: `summary` },
+									{ title: `Summary Large Image`, value: `summary_large_image` },
+									{ title: `App`, value: `app` },
+									{ title: `Player`, value: `player` },
+								],
+							},
+						},
+						{
+							name: `title`,
+							title: `Title`,
+							type: `string`,
+						},
+						{
+							name: `creator`,
+							title: `Creator`,
+							type: `string`,
+						},
+						{
+							name: `twitterImage`,
+							title: `Twitter Image`,
+							type: `image`,
+						},
+						{
+							name: `twitterImageWidth`,
+							title: `Open Graph Image Width`,
+							type: `number`,
+						},
+						{
+							name: `twitterImageHeight`,
+							title: `Open Graph Image Height`,
+							type: `number`,
+						},
+					],
+				},
+			],
+		},
 	],
 };
 


### PR DESCRIPTION
- Add default metadata for home page and dynamic metadata for conference page.
- Update metadata schema for open graph and twitter.


@AlexanderPuhl Opening this as a draft early. Do I need to merge this schema before I can query Sanity with the 'Vision' tab? Just want to build the metadata query in the same way.